### PR TITLE
[FIX] Add retry if first dashboard retrieval fails

### DIFF
--- a/internal/grafana/client.go
+++ b/internal/grafana/client.go
@@ -105,12 +105,11 @@ func GetDashboardInfo(config GrafanaConfig) ([]DashboardInfo, error) {
 
 			if strings.Contains(err.Error(), "status: 404") {
 				logrus.Warn(err)
-				continue
 			} else {
 				get_dashboard_error_total.Inc()
 				logrus.Error(err)
-				continue
 			}
+			continue
 		}
 
 		elapsedSeconds := time.Since(start).Seconds()

--- a/internal/grafana/client.go
+++ b/internal/grafana/client.go
@@ -105,10 +105,11 @@ func GetDashboardInfo(config GrafanaConfig) ([]DashboardInfo, error) {
 
 			if strings.Contains(err.Error(), "status: 404") {
 				logrus.Warn(err)
-			} else {
-				get_dashboard_error_total.Inc()
-				logrus.Error(err)
+				continue
 			}
+
+			get_dashboard_error_total.Inc()
+			logrus.Error(err)
 			continue
 		}
 

--- a/internal/grafana/client.go
+++ b/internal/grafana/client.go
@@ -105,6 +105,7 @@ func GetDashboardInfo(config GrafanaConfig) ([]DashboardInfo, error) {
 
 			if strings.Contains(err.Error(), "status: 404") {
 				logrus.Warn(err)
+				continue
 			} else {
 				get_dashboard_error_total.Inc()
 				logrus.Error(err)

--- a/internal/grafana/client.go
+++ b/internal/grafana/client.go
@@ -70,7 +70,6 @@ func (gc *GrafanaConfig) ReadConfigFile(grafanaApiConfigFile string) error {
 }
 
 func GetDashboardInfo(config GrafanaConfig) ([]DashboardInfo, error) {
-
 	c, err := gapi.New(config.Address, gapi.Config{
 		APIKey: config.ApiKey,
 	})
@@ -97,13 +96,11 @@ func GetDashboardInfo(config GrafanaConfig) ([]DashboardInfo, error) {
 	dashboardsInfos := []DashboardInfo{}
 
 	for _, dashboardSearchResponse := range dashboards {
-
 		start := time.Now()
 
 		dashboard, err := c.DashboardByUID(dashboardSearchResponse.UID)
 
 		if err != nil {
-
 			logrus.Info("Error in retrieving the dashboard. Trying one more time.")
 			dashboard, err = c.DashboardByUID(dashboardSearchResponse.UID)
 

--- a/internal/grafana/client.go
+++ b/internal/grafana/client.go
@@ -2,6 +2,7 @@ package grafana
 
 import (
 	"io/ioutil"
+	"strings"
 	"time"
 
 	gapi "github.com/grafana/grafana-api-golang-client"
@@ -100,15 +101,16 @@ func GetDashboardInfo(config GrafanaConfig) ([]DashboardInfo, error) {
 
 		dashboard, err := c.DashboardByUID(dashboardSearchResponse.UID)
 
-		if err != nil {
-			logrus.Info("Error in retrieving the dashboard. Trying one more time.")
-			dashboard, err = c.DashboardByUID(dashboardSearchResponse.UID)
+		logrus.Info(err)
 
-			if err != nil {
+		if err != nil {
+
+			if strings.Contains(err.Error(), "status: 404") {
+				logrus.Warn(err)
+			} else {
 				get_dashboard_error_total.Inc()
 				logrus.Error(err)
 			}
-
 		}
 
 		elapsedSeconds := time.Since(start).Seconds()

--- a/internal/grafana/client.go
+++ b/internal/grafana/client.go
@@ -101,8 +101,6 @@ func GetDashboardInfo(config GrafanaConfig) ([]DashboardInfo, error) {
 
 		dashboard, err := c.DashboardByUID(dashboardSearchResponse.UID)
 
-		logrus.Info(err)
-
 		if err != nil {
 
 			if strings.Contains(err.Error(), "status: 404") {

--- a/internal/grafana/client.go
+++ b/internal/grafana/client.go
@@ -70,6 +70,7 @@ func (gc *GrafanaConfig) ReadConfigFile(grafanaApiConfigFile string) error {
 }
 
 func GetDashboardInfo(config GrafanaConfig) ([]DashboardInfo, error) {
+
 	c, err := gapi.New(config.Address, gapi.Config{
 		APIKey: config.ApiKey,
 	})
@@ -96,12 +97,21 @@ func GetDashboardInfo(config GrafanaConfig) ([]DashboardInfo, error) {
 	dashboardsInfos := []DashboardInfo{}
 
 	for _, dashboardSearchResponse := range dashboards {
+
 		start := time.Now()
 
 		dashboard, err := c.DashboardByUID(dashboardSearchResponse.UID)
+
 		if err != nil {
-			get_dashboard_error_total.Inc()
-			logrus.Error(err)
+
+			logrus.Info("Error in retrieving the dashboard. Trying one more time.")
+			dashboard, err = c.DashboardByUID(dashboardSearchResponse.UID)
+
+			if err != nil {
+				get_dashboard_error_total.Inc()
+				logrus.Error(err)
+			}
+
 		}
 
 		elapsedSeconds := time.Since(start).Seconds()

--- a/internal/grafana/client.go
+++ b/internal/grafana/client.go
@@ -109,6 +109,7 @@ func GetDashboardInfo(config GrafanaConfig) ([]DashboardInfo, error) {
 			} else {
 				get_dashboard_error_total.Inc()
 				logrus.Error(err)
+				continue
 			}
 		}
 


### PR DESCRIPTION
Occasionally when retrieving the dashboard information, an error would occur with the message:
` "msg="status: 404, body: {\"message\":\"Dashboard not found\"}"`

After some investigation it was concluded that the error occurred when the request to Grafana API coincided with the restart of Grafana pods. 
This PR adds a one-time retry if the GET request fails.